### PR TITLE
theme: Fix native <select> dropdowns needing two clicks to open

### DIFF
--- a/package/gargoyle/files/www/themes/Gargoyle/common.css
+++ b/package/gargoyle/files/www/themes/Gargoyle/common.css
@@ -1305,3 +1305,7 @@ td.share_user_table_column_2
 	display: block;
 	opacity: 1;
 }
+
+/* See theme.css: counterpart override so the #content fix wins regardless of
+   stylesheet load order. */
+#content{-webkit-overflow-scrolling:auto}

--- a/package/gargoyle/files/www/themes/Gargoyle/theme.css
+++ b/package/gargoyle/files/www/themes/Gargoyle/theme.css
@@ -698,3 +698,10 @@ body
 		clear:none;
 	}
 }
+
+/* Fix: native <select> dropdowns needed two clicks to open on desktop Chromium.
+   Cause: -webkit-overflow-scrolling:touch on the #content scroll container.
+   Override to auto (no-op for desktop momentum scrolling) and make selects
+   inline-block. Affects every dropdown on every page. */
+#content{-webkit-overflow-scrolling:auto}
+select,select.form-control{display:inline-block}


### PR DESCRIPTION
## Problem

Every `<select>` dropdown on every page requires two clicks to open on desktop Chromium/Chrome on Linux. The first click flash-opens the dropdown then immediately closes it; the second click works correctly.

This affects all dropdowns across all pages — the connected-hosts dropdowns on the DHCP page, the DHCPv6/RA dropdowns, and any other `<select>` in the UI.

## Root cause

`-webkit-overflow-scrolling: touch` on the `#content` scroll container in `common.css`. This property is intended for iOS momentum scrolling and is a no-op on desktop, but it triggers a known Chromium rendering bug where native select dropdowns inside such a container flash-open and immediately close on the first click.

## Fix

Override the property to `auto` in the theme CSS. Applied in both `theme.css` and `common.css` to cover stylesheet load-order edge cases. Also sets `select { display: inline-block }` which is consistent with the rest of the form controls in the theme.

No JavaScript changes. No functional changes on any other browser or platform.

## Testing

Tested on Chrome on Linux (Ubuntu 22.04). All dropdowns on the DHCP page now open on a single click.