### PR TITLE
dhcp: Skip incomplete UCI host entries with empty MAC

### DIFF
--- a/package/gargoyle/files/www/js/dhcp.js
+++ b/package/gargoyle/files/www/js/dhcp.js
@@ -66,6 +66,7 @@ function saveChanges()
 		tableData = getTableDataArray(staticIpTable, true, false);
 		for(hostIdx = 0; hostIdx < tableData.length; hostIdx++)
 		{
+			if(tableData[hostIdx][1] == "" || tableData[hostIdx][1] == "-") { continue; }
 			cfgid = "static_host_" + (hostIdx+1);
 			uci.set("dhcp",cfgid,"","host");
 			hostname = tableData[hostIdx][0];
@@ -170,6 +171,7 @@ function resetData()
 		hostSection = hostSections[secIndex];
 		host = uciOriginal.get("dhcp",hostSection,"name");
 		mac = uciOriginal.get("dhcp",hostSection,"mac");
+		if(mac == "") { continue; }
 		ipv4 = uciOriginal.get("dhcp",hostSection,"ip");
 		hostid = uciOriginal.get("dhcp",hostSection,"hostid");
 		ipv6 = hostid == "" ? "" : ("00000000" + hostid).slice(-8).replace(/([0-9a-f]{4})([0-9a-f]{4})/i,"::$1:$2");


### PR DESCRIPTION
## Problem

Blank rows can appear in the Static DHCP table when `/etc/config/dhcp` contains a `config host` section with a missing MAC. This happens when the config is written incompletely — e.g. two browser tabs saving the DHCP page at once, or an interrupted write. The blank rows have non-functional edit/remove buttons, and the incomplete host section can also upset dnsmasq.

Reported on the forum: https://www.gargoyle-router.com/phpbb/viewtopic.php?t=18381

## Fix

Defensive skip in two places in `dhcp.js`, so an incomplete host section is simply ignored rather than rendered/written:

1. **Load** (`resetData`) — skip host sections with an empty MAC when building the table, so no blank rows appear.
2. **Save** (`saveChanges`) — skip table rows with an empty MAC when writing UCI back, so an incomplete row is never persisted.

Two lines, no behavioural change for valid entries.

## Testing

- Verified on a GL.iNet MT6000 (Flint 2): a `config host` with no `mac` no longer produces a blank row, and saving no longer writes incomplete host sections back.