### PR TITLE
tor: fix nftables compatibility bugs causing errors and CPU spike

### DIFF
--- a/package/gargoyle-tor/files/tor.firewall
+++ b/package/gargoyle-tor/files/tor.firewall
@@ -4,6 +4,7 @@
 . /usr/lib/bwmon-gargoyle/functions.sh
 
 bwmonscript="/usr/lib/bwmon-gargoyle/bwmon-gargoyle.d/050-tor.bwmon"
+tmp_cron="/tmp/tmp.tor.cron"
 
 if [ -f /tmp/tor.firewall.running ] ; then
 	exit
@@ -83,7 +84,7 @@ initialize()
 				touch "$enabled_ip_file" 
 			fi
 		
-			nft delete set inet fw4 tor_active_ips4
+			nft delete set inet fw4 tor_active_ips4 2>/dev/null
 			nft add set inet fw4 tor_active_ips4 \{ type ipv4_addr\; \}
 			for ip in $(cat $enabled_ip_file) ; do nft add element inet fw4 tor_active_ips4 \{ $ip \} ; done
 			
@@ -146,9 +147,9 @@ initialize()
 	fi
 	
 	if [ "$enabled" != "0" ]  && [ "$relay_mode$client_mode" != "00" ] ; then
-		# enable rebuilding tor_relays ipset
+		# enable rebuilding tor_relays nftset
 		touch /etc/crontabs/root
-		grep -v /usr/sbin/update_tor_nftset > "$tmp_cron"
+		grep -v /usr/sbin/update_tor_nftset /etc/crontabs/root > "$tmp_cron"
 		echo "* * * * * /usr/sbin/update_tor_nftset" >> "$tmp_cron"
 	
 		update_cron
@@ -161,7 +162,7 @@ shutdown()
 {
 	touch /etc/crontabs/root
 
-	grep -v /usr/sbin/update_tor_nftset > "$tmp_cron"
+	grep -v /usr/sbin/update_tor_nftset /etc/crontabs/root > "$tmp_cron"
 	update_cron
 
 	clear_chains
@@ -185,4 +186,3 @@ elif [ "$RUN_MODE" = "stop" ] ; then
 fi
 
 rm /tmp/tor.firewall.running
-

--- a/package/gargoyle-tor/files/update_tor_nftset
+++ b/package/gargoyle-tor/files/update_tor_nftset
@@ -15,8 +15,8 @@ if [ ! -f "$cache_file" ] ; then
 	cache_file="$tor_dir/cached-microdesc-consensus"
 fi
 
-nft add set inet fw4 tor_relays4 \{ type ipv4_addr\; \} 2>/dev/null
-nft add set inet fw4 tor_relays6 \{ type ipv6_addr\; \} 2>/dev/null
+nft add set inet bwmon tor_relays4 \{ type ipv4_addr\; \} 2>/dev/null
+nft add set inet bwmon tor_relays6 \{ type ipv6_addr\; \} 2>/dev/null
 old_md5sum=""
 if [ -f /tmp/tor-consensus-md5 ] ; then
 	old_md5sum=$(cat  /tmp/tor-consensus-md5 )
@@ -28,12 +28,12 @@ if [ -f "$cache_file" ] ; then
 		tor_ips=$(cat "$cache_file" | grep "^r " | awk ' { print $(NF-2) } ' | sort | uniq)
 		# batch all relay IPs into one nft -f - call (avoids ~10k fork/exec per update)
 		{
-			printf "flush set inet fw4 tor_relays4\n"
-			printf "flush set inet fw4 tor_relays6\n"
+			printf "flush set inet bwmon tor_relays4\n"
+			printf "flush set inet bwmon tor_relays6\n"
 			for tip in $tor_ips ; do
 				case "$tip" in
-					*:*) printf "add element inet fw4 tor_relays6 { %s }\n" "$tip" ;;
-					*)   printf "add element inet fw4 tor_relays4 { %s }\n" "$tip" ;;
+					*:*) printf "add element inet bwmon tor_relays6 { %s }\n" "$tip" ;;
+					*)   printf "add element inet bwmon tor_relays4 { %s }\n" "$tip" ;;
 				esac
 			done
 		} | nft -f -

--- a/package/gargoyle-tor/files/update_tor_nftset
+++ b/package/gargoyle-tor/files/update_tor_nftset
@@ -26,12 +26,17 @@ if [ -f "$cache_file" ] ; then
 	new_md5sum=$(md5sum "$cache_file" | awk ' { print $1 ; } ' )
 	if [ "$old_md5sum" != "$new_md5sum" ] ; then 
 		tor_ips=$(cat "$cache_file" | grep "^r " | awk ' { print $(NF-2) } ' | sort | uniq)
-		nft flush set inet fw4 tor_relays4
-		nft flush set inet fw4 tor_relays6
-		for tip in $tor_ips ; do
-			nft add element inet fw4 tor_relays4 \{ $tip \} 2>/dev/null
-			nft add element inet fw4 tor_relays6 \{ $tip \} 2>/dev/null
-		done
+		# batch all relay IPs into one nft -f - call (avoids ~10k fork/exec per update)
+		{
+			printf "flush set inet fw4 tor_relays4\n"
+			printf "flush set inet fw4 tor_relays6\n"
+			for tip in $tor_ips ; do
+				case "$tip" in
+					*:*) printf "add element inet fw4 tor_relays6 { %s }\n" "$tip" ;;
+					*)   printf "add element inet fw4 tor_relays4 { %s }\n" "$tip" ;;
+				esac
+			done
+		} | nft -f -
 		echo "$new_md5sum" > /tmp/tor-consensus-md5
 	fi
 fi

--- a/package/gargoyle-tor/files/update_tor_nftset
+++ b/package/gargoyle-tor/files/update_tor_nftset
@@ -15,8 +15,8 @@ if [ ! -f "$cache_file" ] ; then
 	cache_file="$tor_dir/cached-microdesc-consensus"
 fi
 
-nft add set inet fw4 tor_relays4 \{ type ipv4_addr\; \}
-nft add set inet fw4 tor_relays6 \{ type ipv6_addr\; \}
+nft add set inet fw4 tor_relays4 \{ type ipv4_addr\; \} 2>/dev/null
+nft add set inet fw4 tor_relays6 \{ type ipv6_addr\; \} 2>/dev/null
 old_md5sum=""
 if [ -f /tmp/tor-consensus-md5 ] ; then
 	old_md5sum=$(cat  /tmp/tor-consensus-md5 )

--- a/package/plugin-gargoyle-tor/files/usr/lib/bwmon-gargoyle/bwmon-gargoyle.d/050-tor.bwmon
+++ b/package/plugin-gargoyle-tor/files/usr/lib/bwmon-gargoyle/bwmon-gargoyle.d/050-tor.bwmon
@@ -105,9 +105,11 @@ setup()
 				[ -n "$rport" ] && comma=","
 			fi
 
-			nft add rule $download_table $download_chain tcp dport \{ $rport$comma$oport \} ct mark set ct mark \& 0x0FFFFFFF \| 0xF0000000
-			nft add rule $download_table $download_chain ip saddr @tor_relays ct mark set ct mark \& 0x0FFFFFFF \| 0xF0000000
-			nft add rule $upload_table $upload_chain ip daddr @tor_relays ct mark set ct mark \& 0x0FFFFFFF \| 0xF0000000
+			if [ -n "$rport" ] || [ -n "$oport" ] ; then
+				nft add rule $download_table $download_chain tcp dport \{ $rport$comma$oport \} ct mark set ct mark \& 0x0FFFFFFF \| 0xF0000000
+			fi
+			nft add rule $download_table $download_chain ip saddr @tor_relays4 ct mark set ct mark \& 0x0FFFFFFF \| 0xF0000000
+			nft add rule $upload_table $upload_chain ip daddr @tor_relays4 ct mark set ct mark \& 0x0FFFFFFF \| 0xF0000000
 			nft add rule $download_table $download_chain ct mark \& 0xF0000000 != 0xF0000000 return
 			nft add rule $upload_table $upload_chain ct mark \& 0xF0000000 != 0xF0000000 return
 


### PR DESCRIPTION
Three scripts in the Tor package have nftables compatibility issues that
cause visible errors on startup and a CPU spike every minute when Tor is
active. Diagnosed from a reported log in the forum (thread #18349).

## Changes

**package/gargoyle-tor/files/tor.firewall**

- Define `tmp_cron="/tmp/tmp.tor.cron"` — this variable is used by
  `update_cron` (sourced from `functions.sh`) and by the inline cron
  management in `initialize()`/`shutdown()`, but was never set in this
  file. Only `050-tor.bwmon` defined it, so `tor.firewall` ran with an
  empty variable, causing the `can't create`, `md5sum ''`, and
  `mv: can't rename ''` errors seen at every start/stop.
- Pass `/etc/crontabs/root` explicitly to both `grep -v update_tor_nftset`
  calls. Previously `grep ... > "$tmp_cron"` with an undefined `tmp_cron`
  would silently discard crontab content into nowhere.
- Add `2>/dev/null` to `nft delete set inet fw4 tor_active_ips4` — on
  the first run the set does not yet exist, causing a spurious
  `Error: Could not process rule` in the log.

**package/plugin-gargoyle-tor/files/usr/lib/bwmon-gargoyle/bwmon-gargoyle.d/050-tor.bwmon**

- Rename `@tor_relays` → `@tor_relays4` to match the actual set names
  created by `update_tor_nftset` (`tor_relays4` / `tor_relays6`). The
  old name produced `Error: No such file or directory; did you mean set
  'tor_relays4'?` on every firewall init.
- Guard the `tcp dport \{ $rport$comma$oport \}` rule behind a check
  that at least one port is set. When relay mode is disabled both
  variables are empty, producing `tcp dport { }` which nftables rejects
  with `unexpected '}'` (iptables --multiport accepted an empty list).

**package/gargoyle-tor/files/update_tor_nftset**

- Replace the per-IP loop (`nft add element … { $tip }` called once per
  relay) with a single `nft -f -` batch. The Tor consensus has ~10,000
  relay IPs; the old loop spawned ~20,000 `nft` processes every minute,
  causing the 58% CPU spike visible in `top` whenever the consensus
  changes. The batch also correctly separates IPv4 and IPv6 addresses
  rather than attempting to add every IP to both sets.