### PR TITLE
ksmbd: fix hotplug creating shares with wrong UCI section type

### DIFF
--- a/package/ksmbd-tools/files/ksmbd.hotplug
+++ b/package/ksmbd-tools/files/ksmbd.hotplug
@@ -41,7 +41,7 @@ device_get_vars() {
 	}
 	[ -n "$mount" ] && {
 		uci -c /var/run/config batch <<-EOF
-			set ksmbd.$DEVICE="share"
+			set ksmbd.$DEVICE="sambashare"
 			set ksmbd.$DEVICE.name="${label:-$DEVICE}"
 			set ksmbd.$DEVICE.path="$mount"
 			set ksmbd.$DEVICE.browseable="yes"


### PR DESCRIPTION
`ksmbd.hotplug` was creating UCI sections of type `share` when a USB
drive is inserted. `ksmbd.init` only iterates sections of type
`sambashare` (via `config_foreach smb_add_share sambashare`), so the
hotplug-created entries were never written to `ksmbd.conf` and
auto-detected shares did not work at all.

`samba36`'s hotplug correctly uses `sambashare`. Align `ksmbd.hotplug`
to match.