### PR TITLE
web: fix multi-tab UCI race and session-expiry silent failure

### DIFF
--- a/package/gargoyle/files/www/js/common.js
+++ b/package/gargoyle/files/www/js/common.js
@@ -233,6 +233,12 @@ function runAjax(method, url, params, stateChangeFunction)
 	{
 		req.onreadystatechange = function()
 		{
+			if(req.readyState == 4 && req.responseURL && req.responseURL.indexOf("login.sh") !== -1)
+			{
+				setControlsEnabled(true);
+				window.location.href = req.responseURL;
+				return;
+			}
 			stateChangeFunction(req);
 		}
 

--- a/package/gargoyle/files/www/utility/run_commands.sh
+++ b/package/gargoyle/files/www/utility/run_commands.sh
@@ -11,14 +11,13 @@
 	echo ""
 
 	if [ -n "$FORM_commands" ] ; then
-
-		tmp_file="/tmp/tmp.sh"
-		printf "%s" "$FORM_commands" | tr -d "\r" > $tmp_file
-		sh $tmp_file
-
-		if [ -e $tmp_file ] ; then
-			rm $tmp_file
-		fi
+		tmp_file=$(mktemp /tmp/gargoyle_cmd.XXXXXX.sh)
+		printf "%s" "$FORM_commands" | tr -d "\r" > "$tmp_file"
+		(
+			flock -x 200
+			sh "$tmp_file"
+		) 200>/var/lock/gargoyle_uci.lock
+		rm -f "$tmp_file"
 	fi
 	echo "Success"
 ?>


### PR DESCRIPTION
## Summary

Two related bugs in the web UI that have caused recurring forum reports — both stem from `utility/run_commands.sh`.

---

## Bug 1: Multi-tab concurrent save corrupts UCI config

### Root cause

`run_commands.sh` writes every page's UCI commands to a single fixed path with no locking:

```sh
tmp_file="/tmp/tmp.sh"
printf "%s" "$FORM_commands" | tr -d "\r" > $tmp_file
sh $tmp_file
```

When two pages save at roughly the same time (e.g. DHCP page and QoS page open in separate tabs), the second request overwrites `/tmp/tmp.sh` before the first `sh` call has consumed it. Possible outcomes:

- Tab A executes Tab B's commands instead of its own — changes silently lost
- Tab B's commands run twice — service restarted unnecessarily
- The `sh` process starts reading the file as it is being truncated and overwritten, producing a partial/mixed command set

Any of these leave UCI in an inconsistent state. When the affected service (dnsmasq, firewall, QoS shaper) is then restarted from that state it can crash, which is the crash users report on the forum.

### Fix

```sh
tmp_file=$(mktemp /tmp/gargoyle_cmd.XXXXXX.sh)
printf "%s" "$FORM_commands" | tr -d "\r" > "$tmp_file"
(
    flock -x 200
    sh "$tmp_file"
) 200>/var/lock/gargoyle_uci.lock
rm -f "$tmp_file"
```

`mktemp` gives every request its own file, eliminating the overwrite race. `flock` serialises the actual command execution so that `uci commit` calls from concurrent requests cannot interleave writes to the same config file.

---

## Bug 2: Session expiry causes silent data loss and frozen UI

### Root cause

When a session expires the server-side validator correctly outputs a `302 → login.sh` redirect and calls `exit`, so no UCI commands are executed. The problem is entirely on the client side.

`runAjax` in `common.js` passes every response directly to the caller's `stateChangeFunction` with no pre-check:

```js
req.onreadystatechange = function()
{
    stateChangeFunction(req);
}
```

XHR follows 302 redirects automatically and transparently. By the time `stateChangeFunction` runs, `req.status` is `200` and `req.responseText` is the full HTML of the login page. The typical handler on every page just does:

```js
if(req.readyState == 4)
{
    setControlsEnabled(true);
    window.location.href = window.location.href;   // reload current page
}
```

A page reload also hits an expired session, so the browser ends up on the login page — but the user's unsaved form input is gone with no explanation. They have no way to know whether their changes were saved or not.

**The UI freeze**: Pages with background polling timers (bandwidth graphs, quota usage) keep firing AJAX requests after expiry. Those requests also get login page HTML back. If the response parsing throws an uncaught JS exception before `setControlsEnabled(true)` runs, the grey `darken` wait overlay stays permanently visible and the page appears completely frozen.

### Fix

Intercept the redirect centrally in `runAjax`, before the caller's handler runs:

```js
req.onreadystatechange = function()
{
    if(req.readyState == 4 && req.responseURL && req.responseURL.indexOf("login.sh") !== -1)
    {
        setControlsEnabled(true);
        window.location.href = req.responseURL;
        return;
    }
    stateChangeFunction(req);
}
```

`req.responseURL` is the final URL after following redirects (supported in all modern browsers). When it contains `login.sh` the overlay is cleared and the browser navigates there directly — the login page already handles `?expired=1` to show the appropriate message. No per-page changes needed.

---

## Files changed

| File | Change |
|------|--------|
| `package/gargoyle/files/www/utility/run_commands.sh` | `mktemp` unique file + `flock` serialisation |
| `package/gargoyle/files/www/js/common.js` | Session-expiry redirect detection in `runAjax` |

## Alternative approaches

If you prefer a different direction:

- **run_commands.sh**: Instead of `flock`, a named pipe or a queue script could serialise requests, but `flock` is already available on OpenWrt and has zero dependencies.
- **common.js**: Instead of checking `responseURL`, the server could return a distinct HTTP status (e.g. 401) for expired sessions and we check `req.status`. This requires touching `run_commands.sh` to not use `-r` (redirect mode) of the session validator. Cleaner protocol but more moving parts.
- **Session warning**: A proactive approach would add a client-side countdown that warns the user before expiry (based on the `exp` cookie value). This is a separate, additive change on top of this fix.