### PR TITLE
wifi: allow independent encryption and password per AP band

### DIFF
--- a/package/gargoyle/files/www/basic.sh
+++ b/package/gargoyle/files/www/basic.sh
@@ -1058,6 +1058,29 @@ var isb43 = wirelessDriver == "mac80211" && (!GwifiN) ? true : false ;
 					</span>
 				</div>
 
+				<div id="wifi_encryption1a_container" class="row indent">
+					<label class="col-xs-5" for="wifi_encryption1a" id="wifi_encryption1a_label">5GHz <%~ Encr %>:</label>
+					<span class="col-xs-7" >
+						<select id="wifi_encryption1a" class="form-control" onchange="setWifiVisibility(); proofreadPass('wifi_pass1a', this)">
+							<option value="none"><%~ None %></option>
+							<option value="sae-mixed">WPA3/WPA2 SAE/PSK</option>
+							<option value="sae">WPA3 SAE</option>
+							<option value="psk2">WPA2 PSK</option>
+							<option value="psk">WPA PSK</option>
+							<option value="owe">OWE</option>
+						</select>
+					</span>
+				</div>
+
+				<div id="wifi_pass1a_container" class="row indent">
+					<label class="col-xs-5" for="wifi_pass1a" id="wifi_pass1a_label">5GHz <%~ Pswd %>:</label>
+					<span class="col-xs-7" >
+						<input type="password" id="wifi_pass1a" class="form-control" size="20" oninput="proofreadPass(this, 'wifi_encryption1a')" autocomplete="new-password"/>&nbsp;&nbsp;
+						<input type="checkbox" id="show_pass1a" onclick="togglePass('wifi_pass1a')" autocomplete="off"/>
+						<label for="show_pass1a" id="show_pass1a_label"><%~ rvel %></label><br/>
+					</span>
+				</div>
+
 				<div id="wifi_server1_container" class="row indent">
 					<label class="col-xs-5" for="wifi_server1" id="wifi_server1_label">RADIUS <%~ Srvr %> IP:</label>
 					<span class="col-xs-7" >

--- a/package/gargoyle/files/www/js/basic.js
+++ b/package/gargoyle/files/www/js/basic.js
@@ -845,7 +845,17 @@ function saveChanges()
 					var ssid = document.getElementById("wifi_ssid1a").value;
 					uci.set("wireless", ap2cfg, "ssid", ssid );
 					ssid || uci.set("wireless", ap2cfg, "disabled", "1");
-					dup_sec_options("wireless", apcfg, ap2cfg, ['ieee80211r', 'ft_psk_generate_local', 'pmk_r1_push', 'r0kh', 'r1kh', 'hidden', 'isolate', 'encryption', 'key', 'auth_server', 'auth_port'])
+					dup_sec_options("wireless", apcfg, ap2cfg, ['ieee80211r', 'ft_psk_generate_local', 'pmk_r1_push', 'r0kh', 'r1kh', 'hidden', 'isolate', 'auth_server', 'auth_port'])
+					var enc1a = getSelectedValue("wifi_encryption1a");
+					uci.set("wireless", ap2cfg, "encryption", enc1a);
+					if(enc1a != "none" && enc1a != "owe")
+					{
+						uci.set("wireless", ap2cfg, "key", document.getElementById("wifi_pass1a").value);
+					}
+					else
+					{
+						uci.remove("wireless", ap2cfg, "key");
+					}
 				}
 				if(apgn2cfg != "")
 				{
@@ -1300,6 +1310,7 @@ function proofreadAll()
 	var vn = validateNumeric;
 	var vid = validateSsid;
 	var vp = function(text){ return validatePass(text, 'wifi_encryption1'); }
+	var vp1a = function(text){ return validatePass(text, 'wifi_encryption1a'); }
 	var vpg = function(text){ return validatePass(text, 'wifi_guest_encryption1'); }
 	var vp2 = function(text){ return validatePass(text, 'wifi_encryption2'); }
 	var vpb = function(text){ return validatePass(text, 'bridge_encryption'); }
@@ -1330,14 +1341,14 @@ function proofreadAll()
 		var inputIds = [
 				'wan_pppoe_user', 'wan_pppoe_pass', 'wan_pppoe_max_idle', 'wan_pppoe_reconnect_pings', 'wan_pppoe_interval', 'wan_static_ip', 'wan_static_mask', 'wan_static_gateway', 'wan_mac', 'wan_mtu', 'wan_static_ip6', 'wan_static_gateway6','wan_vlan',
 				'lan_ip', 'lan_mask', 'lan_gateway', 'lan_ip6assign', 'lan_ip6hint', 'lan_ip6ifaceid', 'lan_ip6gw',
-				'wifi_txpower', 'wifi_txpower_5ghz', 'wifi_ssid1', 'wifi_pass1', 'wifi_ft_key', 'wifi_guest_pass1', 'wifi_server1', 'wifi_port1', 'wifi_ssid2', 'wifi_pass2',
+				'wifi_txpower', 'wifi_txpower_5ghz', 'wifi_ssid1', 'wifi_pass1', 'wifi_pass1a', 'wifi_ft_key', 'wifi_guest_pass1', 'wifi_server1', 'wifi_port1', 'wifi_ssid2', 'wifi_pass2',
 				'wan_3g_device', 'wan_3g_apn'
 		];
 
 		var functions= [
 				vlr1, vlr1, vn, vn, vn, vip, vnm, vip, vm, vn, vip6fr, vip6, vwv,
 				vip, vnm, vip, vip6m, vip6h, vip6if, vip6,
-				vtp, vtpa, vid, vp, vfk, vpg, vip, vnp, vid, vp2,
+				vtp, vtpa, vid, vp, vp1a, vfk, vpg, vip, vnp, vid, vp2,
 				vlr1, vlr1
 		];
 
@@ -1564,6 +1575,7 @@ function setWifiVisibility()
 			names.push('OWE');
 		}
 		setAllowableSelections('wifi_encryption1', values, names);
+		setAllowableSelections('wifi_encryption1a', values, names);
 	}
 	else
 	{
@@ -1579,6 +1591,7 @@ function setWifiVisibility()
 			values.push('owe');
 			names.push('OWE');
 		}
+		setAllowableSelections('wifi_encryption1a', values.slice(), names.slice());
 		if(wpad_eap)
 		{
 			values.push('wpa2');
@@ -1703,6 +1716,8 @@ function setWifiVisibility()
 			'wifi_encryption2_container',
 			'wifi_fixed_encryption2_container',
 			'wifi_pass2_container',
+			'wifi_encryption1a_container',
+			'wifi_pass1a_container',
 			];
 
 	var ae = wifiDevA != "" ? 1 : 0; //A band exists
@@ -1716,6 +1731,9 @@ function setWifiVisibility()
 	var e1 = document.getElementById('wifi_encryption1').value;
 	var p1 = (e1 != 'none' && e1 != 'owe') ? 1 : 0;
 	var r1 = (e1 == 'wpa' || e1 == 'wpa2') ? 1 : 0;
+	var da = (g && a) ? 1 : 0;
+	var e1a = da ? document.getElementById('wifi_encryption1a').value : 'none';
+	var p1a = da && (e1a != 'none' && e1a != 'owe') ? 1 : 0;
 	var k1 = r1 && (getSelectedValue('wifi_ft') == "enabled" ? 1 : 0);
 	var gns = (wirelessDriver == "mac80211" && !isb43); //drivers that support guest networks
 	var gn = getSelectedValue("wifi_guest_mode") != "disabled" ? 1 : 0;
@@ -1730,11 +1748,11 @@ function setWifiVisibility()
 	var p2 = e2.match(/sae/) || e2.match(/psk/) || e2.match(/WPA/) ? 1 : 0;
 
 	var wifiVisibilities = new Array();
-	wifiVisibilities['ap']       = [1,1,gw,g,ae,aw,a,1,mf,   1,a,1,0,a,as2,p1,k1,1,1,1,p1,r1,r1, gns,gng,gna,gp1,gn,gn,gn,gp1,gns,   0,0,  0,0,0,0,0,0,0,0,0,0,0 ];
-	wifiVisibilities['ap+wds']   = [1,1,gw,g,ae,aw,a,1,mf,   1,0,1,0,0,0,p1,k1,1,1,1,p1,r1,r1,   gns,gng,gna,gp1,gn,gn,gn,gp1,gns,   b,b,  0,0,0,0,0,0,0,0,0,0,0 ];
-	wifiVisibilities['sta']      = [1,1,gw,g,ae,aw,a,1,mf,   0,0,0,0,0,0,0,0,0,0,0,0,0,0,        0,0,0,0,0,0,0,0,0,                  0,0,  0,0,0,1,g,0,a,0,1,0,p2];
-	wifiVisibilities['ap+sta']   = [1,1,gw,g,ae,aw,a,1,mf,   1,a,1,0,a,as2,p1,k1,1,1,1,p1,r1,r1, gns,gng,gna,gp1,gn,gn,gn,gp1,gns,   0,0,  1,0,0,1,g,0,a,a,1,0,p2];
-	wifiVisibilities['disabled'] = [0,0,0,0,0,0,0,0,0,       0,0,0,0,0,0,0,0,0,0,0,0,0,0,        0,0,0,0,0,0,0,0,0,                  0,0,  0,0,0,0,0,0,0,0,0,0,0 ];
+	wifiVisibilities['ap']       = [1,1,gw,g,ae,aw,a,1,mf,   1,a,1,0,a,as2,p1,k1,1,1,1,p1,r1,r1, gns,gng,gna,gp1,gn,gn,gn,gp1,gns,   0,0,  0,0,0,0,0,0,0,0,0,0,0, da,p1a];
+	wifiVisibilities['ap+wds']   = [1,1,gw,g,ae,aw,a,1,mf,   1,0,1,0,0,0,p1,k1,1,1,1,p1,r1,r1,   gns,gng,gna,gp1,gn,gn,gn,gp1,gns,   b,b,  0,0,0,0,0,0,0,0,0,0,0, da,p1a];
+	wifiVisibilities['sta']      = [1,1,gw,g,ae,aw,a,1,mf,   0,0,0,0,0,0,0,0,0,0,0,0,0,0,        0,0,0,0,0,0,0,0,0,                  0,0,  0,0,0,1,g,0,a,0,1,0,p2, 0,0];
+	wifiVisibilities['ap+sta']   = [1,1,gw,g,ae,aw,a,1,mf,   1,a,1,0,a,as2,p1,k1,1,1,1,p1,r1,r1, gns,gng,gna,gp1,gn,gn,gn,gp1,gns,   0,0,  1,0,0,1,g,0,a,a,1,0,p2, da,p1a];
+	wifiVisibilities['disabled'] = [0,0,0,0,0,0,0,0,0,       0,0,0,0,0,0,0,0,0,0,0,0,0,0,        0,0,0,0,0,0,0,0,0,                  0,0,  0,0,0,0,0,0,0,0,0,0,0, 0,0];
 
 	var wifiVisibility = wifiVisibilities[ wifiMode ];
 	setVisibility(wifiIds, wifiVisibility);
@@ -2557,7 +2575,7 @@ function resetData()
 		setSelectedValue("wifi_hwmode_5ghz", hwAmode);
 	}
 
-	var wirelessIds=['wifi_channel1', 'wifi_channel2', 'wifi_channel1_5ghz', 'wifi_channel1_seg2_5ghz', 'wifi_channel2_5ghz', 'wifi_ssid1', 'wifi_ssid1a', 'wifi_encryption1', 'wifi_pass1', 'wifi_guest_ssid1', 'wifi_guest_mac_g', 'wifi_guest_ssid1a', 'wifi_guest_mac_a', 'wifi_guest_encryption1', 'wifi_guest_pass1',        'wifi_server1', 'wifi_port1', 'wifi_ssid2', 'wifi_encryption2', 'wifi_pass2'];
+	var wirelessIds=['wifi_channel1', 'wifi_channel2', 'wifi_channel1_5ghz', 'wifi_channel1_seg2_5ghz', 'wifi_channel2_5ghz', 'wifi_ssid1', 'wifi_ssid1a', 'wifi_encryption1', 'wifi_pass1', 'wifi_guest_ssid1', 'wifi_guest_mac_g', 'wifi_guest_ssid1a', 'wifi_guest_mac_a', 'wifi_guest_encryption1', 'wifi_guest_pass1',        'wifi_server1', 'wifi_port1', 'wifi_ssid2', 'wifi_encryption2', 'wifi_pass2', 'wifi_encryption1a', 'wifi_pass1a'];
 	var wirelessPkgs= new Array();
 	var wIndex;
 	for(wIndex=0; wIndex < wirelessIds.length; wIndex++)
@@ -2567,10 +2585,10 @@ function resetData()
 	var default5ID = uciOriginal.get("wireless", apcfg, "ssid") ? uciOriginal.get("wireless", apcfg, "ssid") + " 5GHz" : "Gargoyle 5GHz";
 	var defaultGuest5ID = apgncfg && uciOriginal.get("wireless", apgncfg, "ssid") ? uciOriginal.get("wireless", apgncfg, "ssid") + " 5GHz" : "Guests 5GHz";
 
-	var wirelessSections=[wifiDevG, wifiDevG, wifiDevA, wifiDevA, wifiDevA, apgcfg, apacfg, apcfg, apcfg,                                                                apgngcfg, apgngcfg, apgnacfg, apgnacfg, apgncfg, apgncfg,               apcfg, apcfg, othercfg, othercfg, othercfg];
-	var wirelessOptions=['channel', 'channel', 'channel', 'channel2', 'channel', 'ssid', 'ssid', 'encryption', 'key',                                                    'ssid', 'macaddr', 'ssid', 'macaddr', 'encryption', 'key',                   'auth_server', 'auth_port', 'ssid', 'encryption', 'key'];
-	var wirelessParams=["5", "5", "36","36","36", 'Gargoyle', default5ID, 'none','',        'Guests', '', defaultGuest5ID, '', 'none', '',                                  '', '', 'ExistingWireless', 'none', ''];
-	var wirelessFunctions=[lsv, lsv, lsv,lsv, lsv, lv, lv, lsv, lv,                                                                                                 lv, lv, lv, lv, lsv, lv,                                                        lv, lv, lv, lsv, lv];
+	var wirelessSections=[wifiDevG, wifiDevG, wifiDevA, wifiDevA, wifiDevA, apgcfg, apacfg, apcfg, apcfg,                                                                apgngcfg, apgngcfg, apgnacfg, apgnacfg, apgncfg, apgncfg,               apcfg, apcfg, othercfg, othercfg, othercfg, apacfg, apacfg];
+	var wirelessOptions=['channel', 'channel', 'channel', 'channel2', 'channel', 'ssid', 'ssid', 'encryption', 'key',                                                    'ssid', 'macaddr', 'ssid', 'macaddr', 'encryption', 'key',                   'auth_server', 'auth_port', 'ssid', 'encryption', 'key', 'encryption', 'key'];
+	var wirelessParams=["5", "5", "36","36","36", 'Gargoyle', default5ID, 'none','',        'Guests', '', defaultGuest5ID, '', 'none', '',                                  '', '', 'ExistingWireless', 'none', '', 'none', ''];
+	var wirelessFunctions=[lsv, lsv, lsv,lsv, lsv, lv, lv, lsv, lv,                                                                                                 lv, lv, lv, lv, lsv, lv,                                                        lv, lv, lv, lsv, lv, lsv, lv];
 
 	loadVariables(uciOriginal, wirelessIds, wirelessPkgs, wirelessSections, wirelessOptions, wirelessParams, wirelessFunctions);
 
@@ -4013,6 +4031,20 @@ function setHwMode(selectCtl)
 
 		setWifiVisibility();
 	}
+
+	//the per-band 5GHz encryption/password fields are driven only by the
+	//setWifiVisibility table, but setHwMode can be reached on its own when a
+	//radio is toggled (it is not routed through setWifiVisibility). Refresh them
+	//here too -- directly, not by calling setWifiVisibility (which would recurse
+	//via its own setHwMode call) -- so the 5GHz encryption field can never stay
+	//hidden while saveChanges still writes its value.
+	var perBandMode = getSelectedValue("wifi_mode");
+	var gEnabled = getSelectedValue("wifi_hwmode") == "disabled" ? 0 : 1;
+	var aEnabled = getSelectedValue("wifi_hwmode_5ghz") == "disabled" ? 0 : 1;
+	var showEnc1a = (gEnabled && aEnabled) && (perBandMode == "ap" || perBandMode == "ap+sta" || perBandMode == "ap+wds");
+	var enc1a = document.getElementById("wifi_encryption1a").value;
+	document.getElementById("wifi_encryption1a_container").style.display = showEnc1a ? "block" : "none";
+	document.getElementById("wifi_pass1a_container").style.display = (showEnc1a && enc1a != "none" && enc1a != "owe") ? "block" : "none";
 }
 
 function getMaxTxPower(band)


### PR DESCRIPTION
Resubmission of #62, which I closed to come back with the visibility fix you requested. This branch is a single commit on top of current `master`; the only change versus #62 is the `setHwMode` refresh described under "Visibility fix" below.

## Problem

In dual-band AP mode both APs are forced to the same encryption type and passphrase because `dup_sec_options` copies `encryption` and `key` from the 2.4 GHz section to the 5 GHz section on every save. There is no way to run WPA3 on 5 GHz while keeping WPA2 on 2.4 GHz for older devices.

## Solution

Adds `wifi_encryption1a` and `wifi_pass1a` UI elements following the existing `wifi_ssid1a` naming convention for 5 GHz-specific fields. The new fields appear only when both bands are active in a real local-AP mode (`ap` / `ap+sta`).

- **`basic.sh`** — two rows after `wifi_pass1_container`: a 5 GHz encryption dropdown (SAE, SAE-mixed, WPA2 PSK, WPA PSK, OWE, none — no RADIUS) and a 5 GHz password with show/hide.
- **`basic.js` save** — drops `encryption`/`key` from the `dup_sec_options` copy to `ap2cfg`; writes the 5 GHz values explicitly; removes the key for `none`/`owe` so no stale key lingers on an open network.
- **`basic.js` load** — both fields added to `wirelessIds`, read from `ap_a`.
- **`basic.js` validation** — `wifi_pass1a` wired into `proofreadAll` via its own `vp1a` validator, bound to `wifi_encryption1a`.

## Visibility fix (your review on #62)

You flagged that switching a 2.4 GHz wireless-client to AP mode and then enabling the 5 GHz radio left the second encryption field hidden while save still wrote its value — a silently unencrypted 5 GHz network — because `setHwMode` does not run `setWifiVisibility`.

Heeding your warning not to just call `setWifiVisibility` from `setHwMode` (it recurses via its own `setHwMode` call), the fix refreshes the two per-band containers **directly** at the end of `setHwMode`, setting their `display` from the same dual-band/AP predicate used in the visibility table. No call into `setWifiVisibility`, so no recursion and no disturbance to the other intertwined visibility logic.

## Testing

The fix was developed against a behavioural test harness that loads the real `common.js` + `basic.js` into a DOM and drives the actual `setWifiVisibility()` / `setHwMode()` functions, reading back `style.display`. Coverage:

- **The exact failure transition** you described — `sta`@2.4 → AP → enable 5 GHz radio via `setHwMode` — now reveals the 5 GHz encryption field; the symmetric case (5 GHz-only AP → enable 2.4) is covered too.
- **Full visibility matrix** — every `wifi_mode` × 2.4 on/off × 5 GHz on/off × 6 encryption types, driven through **both** entry paths (mode change → `setWifiVisibility`, and radio toggle → `setHwMode`), asserted against the rule "shown iff both bands up and mode ∈ {ap, ap+sta}".
- **No-collateral-damage check** — the candidate `basic.js` is A/B diffed against the pre-fix `basic.js` across that whole matrix; the only containers whose visibility differs are the two new per-band fields. Nothing else in the intertwined visibility logic moves.
- **Save correctness** — key written only for keyed encryption, removed for `none`/`owe`.
- **Validator alignment** — `proofreadAll`'s `inputIds[]`/`functions[]` stay the same length and `vp1a` validates against the 5 GHz encryption, not the 2.4.

**On real hardware:** built the `mediatek` target, flashed a GL-iNet MT6000, and confirmed per-band encryption end to end — WPA3 on 5 GHz with WPA2 on 2.4 GHz, joined from a phone on each band.

## Behaviour unchanged

Single-band and WDS modes hide the new fields with no change to the save/load path; the guest network still uses `dup_sec_options`; existing configs with matching encryption on both bands load unchanged (`wifi_encryption1a` reads the current `ap_a` value).
