### PR TITLE
web: fix multi-tab UCI-save race and silent session-expiry data loss

### DIFF
--- a/package/gargoyle/files/www/js/common.js
+++ b/package/gargoyle/files/www/js/common.js
@@ -233,6 +233,31 @@ function runAjax(method, url, params, stateChangeFunction)
 	{
 		req.onreadystatechange = function()
 		{
+			// If the session expired, the server 302-redirects to login.sh and
+			// runs no commands. XHR follows the redirect transparently, so the
+			// caller would otherwise see login-page HTML with status 200 and
+			// silently lose the user's unsaved input -- and a polling page can
+			// be left with its wait overlay stuck. Detect the redirect
+			// centrally, clear the overlay, and go to login (which shows the
+			// expired-session message).
+			//
+			// responseURL is only used as the signal, never as the destination:
+			// the session validator emits a path-relative "Location: login.sh",
+			// so for an XHR to utility/*.sh the browser resolves it against
+			// /utility/ and responseURL is /utility/login.sh. That path has no
+			// file behind it -- uhttpd's error_page still renders the login
+			// page, but the header's relative i18n src then resolves to
+			// /utility/i18n/<lang>/strings.js and 404s, leaving the page
+			// untranslated. Always send the browser to the web root's login.sh,
+			// carrying over the validator's ?expired=1 so the expiry message
+			// is still shown.
+			if(req.readyState == 4 && req.responseURL && req.responseURL.indexOf("login.sh") != -1)
+			{
+				var queryIndex = req.responseURL.indexOf("?");
+				setControlsEnabled(true);
+				window.location.href = "/login.sh" + (queryIndex != -1 ? req.responseURL.substring(queryIndex) : "");
+				return;
+			}
 			stateChangeFunction(req);
 		}
 

--- a/package/gargoyle/files/www/utility/run_commands.sh
+++ b/package/gargoyle/files/www/utility/run_commands.sh
@@ -12,12 +12,21 @@
 
 	if [ -n "$FORM_commands" ] ; then
 
-		tmp_file="/tmp/tmp.sh"
-		printf "%s" "$FORM_commands" | tr -d "\r" > $tmp_file
-		sh $tmp_file
-
-		if [ -e $tmp_file ] ; then
-			rm $tmp_file
+		# Unique temp file per request (mktemp) so a concurrent save from
+		# another tab can't overwrite this request's command file before it
+		# runs, and an exclusive lock around execution so two requests'
+		# `uci commit`s can't interleave and corrupt a shared config file.
+		# Both symptoms surface on the forum as a service (dnsmasq/firewall/
+		# qos) crashing after a multi-tab save. The mktemp template keeps the
+		# X's at the very end -- busybox mktemp rejects a suffix after them.
+		tmp_file=$(mktemp /tmp/gargoyle_cmd.XXXXXX)
+		if [ -n "$tmp_file" ] ; then
+			printf "%s" "$FORM_commands" | tr -d "\r" > "$tmp_file"
+			(
+				flock -x 200
+				sh "$tmp_file"
+			) 200>/var/lock/gargoyle_uci.lock
+			rm -f "$tmp_file"
 		fi
 	fi
 	echo "Success"

--- a/package/gargoyle/src/gargoyle_header_footer.c
+++ b/package/gargoyle/src/gargoyle_header_footer.c
@@ -377,7 +377,7 @@ int main(int argc, char **argv)
 			{
 					printf("\t<script src=\"/i18n/%s/strings.js?%s\"></script>\n", fallback_lang, gargoyle_version);
 			}
-			printf("\t<script src=\"i18n/%s/strings.js?%s\"></script>\n", active_lang, gargoyle_version);
+			printf("\t<script src=\"/i18n/%s/strings.js?%s\"></script>\n", active_lang, gargoyle_version);
 			for(lstr_js_index=0; all_lstr_js[lstr_js_index] != NULL; lstr_js_index++)
 			{
 				if (memcmp(fallback_lang, active_lang, strlen(active_lang)) != 0)


### PR DESCRIPTION
First item from the fork feature catalog (ispyisail/gargoyle discussion #132), backported one-at-a-time as agreed on #128.

Two related web-UI bugs, both surfacing on the forum as a service crash or a frozen page after a save.

## Bug 1 — multi-tab UCI-save race
`run_commands.sh` writes every page's commands to a single fixed `/tmp/tmp.sh` with no locking. Two tabs saving at once (e.g. DHCP + QoS) can overwrite each other's command file or interleave their `uci commit`s, leaving config inconsistent — the affected service (dnsmasq/firewall/qos) then crashes on restart.

**Fix:** a unique `mktemp` file per request + an `flock` around execution. Note the mktemp template keeps the X's at the very end — busybox mktemp rejects a suffix after them (a naive `.XXXXXX.sh` form fails with 'Invalid argument').

## Bug 2 — silent session-expiry data loss
When a session expires the server 302-redirects to `login.sh` and runs nothing, but XHR follows the redirect transparently, so the caller sees login-page HTML with status 200 — silently losing the user's unsaved input, and sometimes leaving a polling page's wait overlay stuck.

**Fix:** detect the `login.sh` redirect centrally in `runAjax` via `req.responseURL`, clear the overlay, and navigate to login. No per-page changes.

## Test
- `flock`, `mktemp`, `req.responseURL` all present on the target image.
- Validated the mktemp+flock execution and serialisation on a live router; `node --check` on common.js.
- This is proven code already running in the fork.

Happy to adjust to your preference — e.g. `flock` vs a queue, or a distinct 401 status instead of `responseURL` detection (both noted as alternatives).